### PR TITLE
Extract cookies from replayed requests and responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - TOX_SUFFIX="urllib3"
     - TOX_SUFFIX="tornado4"
     - TOX_SUFFIX="aiohttp"
+    - TOX_SUFFIX="httpx"
 matrix:
   include:
     # Only run lint on a single 3.x

--- a/tests/integration/cassettes/DoAsyncRequesttest_httpx_test_test_behind_proxy.yml
+++ b/tests/integration/cassettes/DoAsyncRequesttest_httpx_test_test_behind_proxy.yml
@@ -20,14 +20,22 @@ interactions:
       : \"python-httpx/0.12.1\", \n    \"X-Amzn-Trace-Id\": \"Root=1-5ea778c9-ea76170da792abdbf7614067\"\
       \n  }\n}\n"
     headers:
-      access-control-allow-credentials: 'true'
-      access-control-allow-origin: '*'
-      connection: keep-alive
-      content-length: '226'
-      content-type: application/json
-      date: Tue, 28 Apr 2020 00:28:57 GMT
-      server: gunicorn/19.9.0
-      via: my_own_proxy
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-length:
+      - '226'
+      content-type:
+      - application/json
+      date:
+      - Tue, 28 Apr 2020 00:28:57 GMT
+      server:
+      - gunicorn/19.9.0
+      via:
+      - my_own_proxy
     http_version: HTTP/1.1
     status_code: 200
 version: 1

--- a/tests/integration/test_httpx.py
+++ b/tests/integration/test_httpx.py
@@ -157,14 +157,14 @@ def test_work_with_gzipped_data(tmpdir, do_request, yml):
         assert cassette.play_count == 1
 
 
-@pytest.mark.parametrize("url", ["http://github.com/kevin1024/vcrpy/issues/" + str(i) for i in range(3, 6)])
+@pytest.mark.parametrize("url", ["https://github.com/kevin1024/vcrpy/issues/" + str(i) for i in range(3, 6)])
 def test_simple_fetching(tmpdir, do_request, yml, url):
     with vcr.use_cassette(yml):
         do_request()("GET", url)
 
     with vcr.use_cassette(yml) as cassette:
         cassette_response = do_request()("GET", url)
-        cassette_response.request.url == url
+        assert str(cassette_response.request.url) == url
         assert cassette.play_count == 1
 
 
@@ -205,7 +205,7 @@ def test_behind_proxy(do_request):
 
     with vcr.use_cassette(yml) as cassette:
         cassette_response = do_request(proxies=proxies, verify=False)("GET", url)
-        cassette_response.request.url == url
+        assert str(cassette_response.request.url) == url
         assert cassette.play_count == 1
 
         assert cassette_response.headers["Via"] == "my_own_proxy", str(cassette_response.headers)

--- a/vcr/stubs/httpx_stubs.py
+++ b/vcr/stubs/httpx_stubs.py
@@ -97,29 +97,17 @@ def _record_responses(cassette, vcr_request, real_response):
     return real_response
 
 
-def _get_next_url(response):
-    location_str = response.headers.get("location")
-    if not location_str:
-        return None
-
-    next_url = URL(location_str)
-    if not next_url.is_absolute():
-        next_url = URL(str(response.url)).with_path(str(next_url))
-
-    return next_url
-
-
 def _play_responses(cassette, request, vcr_request, client):
     history = []
     vcr_response = cassette.play_response(vcr_request)
     response = _from_serialized_response(request, vcr_response)
 
     while 300 <= response.status_code <= 399:
-        next_url = _get_next_url(response)
+        next_url = response.headers.get("location")
         if not next_url:
             break
 
-        vcr_request = VcrRequest("GET", str(next_url), None, dict(response.headers))
+        vcr_request = VcrRequest("GET", next_url, None, dict(response.headers))
         vcr_request = cassette.find_requests_with_most_matches(vcr_request)[0][0]
 
         history.append(response)


### PR DESCRIPTION
I have noticed an issue where `httpx.Client` would not extract cookies into its cookie jar from replayed requests/responses. This PR fixes it.

Also it changes the persistence format for response headers. Now multiple headers with the same header name are supported. This covers the usecase when response has multiple `Set-Cookie` header set.

Also enabled Travis CI tests and fixed another issue with redirect handling for which I have also added a test.